### PR TITLE
Added to the solution an option for users to optionally set the Alarm State to Ok on Execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3 (2025-04-01)
+
+- Minor update in a Lambda Function to correct the alarm action by setting the alarm state to "OK"
+- Addition IAM permision to allow lambda to set Alarm State
+
 # 0.2 (2024-05-15) - Minor Updates
 
 Addressing Issues #1 and #2. 

--- a/templates/canvas-autoshutdown-all-domains-all-users.yaml
+++ b/templates/canvas-autoshutdown-all-domains-all-users.yaml
@@ -9,6 +9,13 @@ Parameters:
     Type: Number
     Description: Aggregation time (in seconds) used by CloudWatch Alarm to compute the idle timeout. Default value is 20 minutes.
     Default: 1200
+  AlarmState:
+    Type: String
+    AllowedValues: 
+      - "True"
+      - "False"
+    Default: "True"
+    Description: Should your Lambda function automatically set the alarm status to OK after execution. 
 
 Resources:
   DeleteCanvasAppFunction:
@@ -29,7 +36,7 @@ Resources:
           import datetime
           
           def lambda_handler(event, context):
-              region = event['region']
+              region = event['region'] 
               
               try:
                 config = Config(region_name=region)
@@ -51,6 +58,7 @@ Resources:
                 for metric in metric_data_results['MetricDataResults']:
                   domain_id, user_profile_name = metric['Label'].split(' ')
                   latest_value = metric['Values'][-1]
+
                   if latest_value >= int(os.environ['TIMEOUT_THRESHOLD']):
                     status = sagemaker.describe_app(
                       DomainId=domain_id,
@@ -69,6 +77,13 @@ Resources:
                     else:
                       print(f"Canvas App for {user_profile_name} in domain {domain_id} is in {status} status. Will not delete for now.")
                       continue
+                    if os.environ['SET_ALARM_OK'] == "True":
+                      cw_alarm = event['detail']['alarmName']
+                      resp = cloudwatch.set_alarm_state(
+                        AlarmName=cw_alarm,
+                        StateValue='OK',
+                        StateReason='Set to OK by Canvas Shutdown Lambda function',
+                        StateReasonData='{"actionOrigin": "CanvasShutdownAutomation"}') 
               except Exception as e:
                 print(str(e))
                 raise e
@@ -76,6 +91,7 @@ Resources:
         Variables:
           TIMEOUT_THRESHOLD: !Ref IdleTimeout
           ALARM_PERIOD: !Ref AlarmPeriod
+          SET_ALARM_OK: !Ref AlarmState
   EventBridgeLambdaPermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -106,6 +122,7 @@ Resources:
                   - 'logs:CreateLogStream'
                   - 'logs:PutLogEvents'
                   - 'cloudwatch:GetMetricData'
+                  - 'cloudwatch:SetAlarmState'
                 Resource: '*'  
               - Effect: Allow
                 Action:
@@ -114,6 +131,7 @@ Resources:
                 Resource: 
                   - !Sub arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:app/*/*/canvas/default
                   - !Sub arn:aws:sagemaker:${AWS::Region}:${AWS::AccountId}:app/*/*/Canvas/default
+                  
   TimeSinceLastActiveAlarm:
     Type: AWS::CloudWatch::Alarm
     Properties:

--- a/templates/canvas-autoshutdown-one-domain-all-users.yaml
+++ b/templates/canvas-autoshutdown-one-domain-all-users.yaml
@@ -14,6 +14,14 @@ Parameters:
     Description: The domain ID to monitor for idle Canvas apps.
     AllowedPattern: 'd-[a-zA-Z0-9]{12}'
     ConstraintDescription: Must start with 'd-' followed by 12 alphanumeric characters.
+  AlarmState:
+    Type: String
+    AllowedValues: 
+      - "True"
+      - "False"
+    Default: "True"
+    Description: Should your Lambda function automatically set the alarm status to OK after execution. 
+
 
 Resources:
   DeleteCanvasAppFunction:
@@ -34,7 +42,7 @@ Resources:
           import datetime
           
           def lambda_handler(event, context):
-              region = event['region']
+              region = event['region'] 
               
               try:
                 config = Config(region_name=region)
@@ -45,7 +53,7 @@ Resources:
                   MetricDataQueries=[
                       {
                           "Id": "q1",
-                          "Expression": f'SELECT AVG(TimeSinceLastActive) FROM "/aws/sagemaker/Canvas/AppActivity" WHERE DomainId=\'{os.environ['DOMAIN_ID']}\' GROUP BY DomainId, UserProfileName',
+                          "Expression": f'SELECT AVG(TimeSinceLastActive) FROM "/aws/sagemaker/Canvas/AppActivity" WHERE DomainId=\'{os.environ["DOMAIN_ID"]}\' GROUP BY DomainId, UserProfileName',
                           "Period": int(os.environ['ALARM_PERIOD'])
                       }
                   ],
@@ -74,6 +82,13 @@ Resources:
                     else:
                       print(f"Canvas App for {user_profile_name} in domain {domain_id} is in {status} status. Will not delete for now.")
                       continue
+                    if os.environ['SET_ALARM_OK'] == "True":
+                      cw_alarm = event['detail']['alarmName']
+                      resp = cloudwatch.set_alarm_state(
+                        AlarmName=cw_alarm,
+                        StateValue='OK',
+                        StateReason='Set to OK by Canvas Shutdown Lambda function',
+                        StateReasonData='{"actionOrigin": "CanvasShutdownAutomation"}') 
               except Exception as e:
                 print(str(e))
                 raise e
@@ -82,6 +97,7 @@ Resources:
           TIMEOUT_THRESHOLD: !Ref IdleTimeout
           ALARM_PERIOD: !Ref AlarmPeriod
           DOMAIN_ID: !Ref DomainId
+          SET_ALARM_OK: !Ref AlarmState
   EventBridgeLambdaPermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -112,6 +128,8 @@ Resources:
                   - 'logs:CreateLogStream'
                   - 'logs:PutLogEvents'
                   - 'cloudwatch:GetMetricData'
+                  - 'cloudwatch:SetAlarmState'
+                  - 'cloudwatch:DescribeAlarms'
                 Resource: '*'  
               - Effect: Allow
                 Action:

--- a/templates/canvas-autoshutdown-one-domain-one-user.yaml
+++ b/templates/canvas-autoshutdown-one-domain-one-user.yaml
@@ -17,6 +17,13 @@ Parameters:
   UserProfileName: 
     Type: String
     Description: The domain ID to monitor for idle Canvas apps.
+  AlarmState:
+    Type: String
+    AllowedValues: 
+      - "True"
+      - "False"
+    Default: "True"
+    Description: Should your Lambda function automatically set the alarm status to OK after execution. 
 
 Resources:
   DeleteCanvasAppFunction:
@@ -48,7 +55,7 @@ Resources:
                   MetricDataQueries=[
                       {
                           "Id": "q1",
-                          "Expression": f'SELECT AVG(TimeSinceLastActive) FROM "/aws/sagemaker/Canvas/AppActivity" WHERE DomainId=\'{os.environ['DOMAIN_ID']}\' AND UserProfileName=\'{os.environ['USER_PROFILE_NAME']}\' GROUP BY DomainId, UserProfileName',
+                          "Expression": f'SELECT AVG(TimeSinceLastActive) FROM "/aws/sagemaker/Canvas/AppActivity" WHERE DomainId=\'{os.environ.get("DOMAIN_ID")}\' AND UserProfileName=\'{os.environ.get("USER_PROFILE_NAME")}\' GROUP BY DomainId, UserProfileName',
                           "Period": int(os.environ['ALARM_PERIOD'])
                       }
                   ],
@@ -77,6 +84,13 @@ Resources:
                     else:
                       print(f"Canvas App for {user_profile_name} in domain {domain_id} is in {status} status. Will not delete for now.")
                       continue
+                    if os.environ['SET_ALARM_OK'] == "True":
+                      cw_alarm = event['detail']['alarmName']
+                      resp = cloudwatch.set_alarm_state(
+                        AlarmName=cw_alarm,
+                        StateValue='OK',
+                        StateReason='Set to OK by Canvas Shutdown Lambda function',
+                        StateReasonData='{"actionOrigin": "CanvasShutdownAutomation"}') 
               except Exception as e:
                 print(str(e))
                 raise e
@@ -86,6 +100,7 @@ Resources:
           ALARM_PERIOD: !Ref AlarmPeriod
           DOMAIN_ID: !Ref DomainId
           USER_PROFILE_NAME: !Ref UserProfileName
+          SET_ALARM_OK: !Ref AlarmState
   EventBridgeLambdaPermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -116,6 +131,7 @@ Resources:
                   - 'logs:CreateLogStream'
                   - 'logs:PutLogEvents'
                   - 'cloudwatch:GetMetricData'
+                  - 'cloudwatch:SetAlarmState'
                 Resource: '*'  
               - Effect: Allow
                 Action:


### PR DESCRIPTION
The change is inspired by a request by a user to add a layer that persistently makes sure Apps are deleted. 

modified:   CHANGELOG.md
- Added new description notes about the new change

modified:   templates/canvas-autoshutdown-all-domains-all-users.yaml
- Added new parameters and Environ parameter
- Added loging to change allow status change

modified:   templates/canvas-autoshutdown-one-domain-all-users.yaml
- Added new parameters and Environ parameter
- Added loging to change allow status change

modified:   templates/canvas-autoshutdown-one-domain-one-user.yaml
- Added new parameters and Environ parameter
- Added loging to change allow status change

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
